### PR TITLE
Add an initial set of security related guides

### DIFF
--- a/_data/guides.yaml
+++ b/_data/guides.yaml
@@ -13,6 +13,24 @@ categories:
       - title: Configure Application Logging
         url: /guides/application-logging
         description: Learn how to setup and configure logging in WildFly.
+  - category: Security
+    cat-id: security
+    guides:
+      - title: Securing WildFly Apps with OpenID Connect on OpenShift
+        url: /guides/security-oidc-openshift
+        description: Learn how to secure applications deployed to WildFly on OpenShift with OpenID Connect.
+      - title: Identity Propagation with OpenID Connect
+        url: /guides/security-oidc-identity-propagation
+        description: Learn how to propagate identities within a deployment and across deployments when securing WildFly apps with OpenID Connect.
+      - title: Securing WildFly Apps with Auth0 on OpenShift
+        url: /guides/security-oidc-auth0-openshift
+        description: Learn how to secure applications deployed to WildFly on OpenShift with the Auth0 OpenID provider.
+      - title: Securing the WildFly Management Console with OpenID Connect
+        url: /guides/security-oidc-management-console
+        description: Learn how to secure the WildFly management console with the Keycloak OpenID provider.
+      - title: Securing WildFly Apps with SAML on OpenShift
+        url: /guides/security-saml-openshift
+        description: Learn how to secure applications deployed to WildFly on OpenShift with SAML.
   - category: Eclipse MicroProfile
     cat-id: microprofile
     guides:

--- a/guides/_includes/_attributes.adoc
+++ b/guides/_includes/_attributes.adoc
@@ -8,3 +8,5 @@
 :toc: right
 // Default time to display in the prerequisites section
 :prerequisites-time: 15
+// OpenShift Container Platform version
+:ocp-version: 4.14

--- a/guides/_includes/_proc-configure-keycloak.adoc
+++ b/guides/_includes/_proc-configure-keycloak.adoc
@@ -1,0 +1,30 @@
+== Configure Keycloak
+
+. Log into the `Keycloak Admin Console`.
+
+. Create a new realm called `myrealm`. For more information, see the Keycloak documentation on how to https://www.keycloak.org/getting-started/getting-started-openshift#_create_a_realm[create a realm].
+
+ifdef::add-role[]
+. Add a role called `User`. This role will be required to access our simple web application. For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#assigning-permissions-using-roles-and-groups[create a role].
+endif::[]
+
+. Add a new user named `alice`. For more information, see the Keycloak documentation on how to https://www.keycloak.org/getting-started/getting-started-openshift#_create_a_user[create a user].
+
+. Once the new user has been created, set a password for this new user from the `Credentials` tab.
+
+ifdef::add-role[]
+. From the `Role Mapping` tab, assign `alice` the `User` role. For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#proc-assigning-role-mappings_server_administration_guide[assign a role] to a user.
+endif::[]
+
+. Create a new client as follows:
+* `General Settings`:
+** *Client type* (or *Client Protocol*, depending on your Keycloak version): `OpenID Connect`
+** *Client ID*: `myclient`
+* `Capability config`:
+** *Authentication flow*: `Standard flow`, `Direct access grants`
+* `Login settings`: Leave the fields blank for now.
+
++
+For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#_oidc_clients[Manage OpenID Connect clients].
+
+. Click `Save` to save the client.

--- a/guides/_includes/_proc-follow-build-and-deployment-openshift.adoc
+++ b/guides/_includes/_proc-follow-build-and-deployment-openshift.adoc
@@ -1,0 +1,17 @@
+The application will now begin to build. This will take a couple of minutes.
+
+The build can be observed using:
+
+[source,bash]
+----
+oc get build -w
+----
+
+Once complete, you can follow the deployment of the application using:
+
+[source,bash]
+----
+oc get deployment oidc-app -w
+----
+
+Alternatively, you can check status directly from the OpenShift web console.

--- a/guides/_includes/_proc-install-or-update-helm.adoc
+++ b/guides/_includes/_proc-install-or-update-helm.adoc
@@ -1,0 +1,14 @@
+If you haven't already installed the WildFly Helm chart, install it:
+
+[source,bash]
+----
+helm repo add wildfly https://docs.wildfly.org/wildfly-charts/
+----
+
+If you've already installed the WildFly Helm Chart, be sure to update it to ensure you have the latest one:
+
+[source,bash]
+----
+helm repo update
+----
+

--- a/guides/_includes/_proc-log-into-openshift-cluster.adoc
+++ b/guides/_includes/_proc-log-into-openshift-cluster.adoc
@@ -1,0 +1,25 @@
+== Log Into the OpenShift Cluster
+
+Before we can deploy our application, we need to log in to an OpenShift cluster. You can log in via the https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]:
+
+[source,bash]
+----
+oc login -u myUserName
+----
+
+Alternatively, you can log in using an API token:
+
+[source,bash]
+----
+oc login --token=myToken --server=myServerUrl
+----
+
+You can request the token via the `Copy Login Command` link in the OpenShift web console.
+
+If you don't already have a project created, you can create one using:
+
+[source,bash]
+----
+oc new-project myProjectName
+----
+

--- a/guides/_includes/_proc-start-keycloak-openshift.adoc
+++ b/guides/_includes/_proc-start-keycloak-openshift.adoc
@@ -1,0 +1,71 @@
+== Start Keycloak
+
+ifndef::saml-auth-method[]
+We will be using Keycloak as our OpenID provider.
+endif::[]
+ifdef::saml-auth-method[]
+We will be using Keycloak as our SAML identity provider.
+endif::[]
+
+To start a Keycloak server in your project on OpenShift, use the following command:
+
+[source,bash]
+----
+oc process -f https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/openshift/keycloak.yaml \
+    -p KEYCLOAK_ADMIN=admin                    \// <1>
+    -p KEYCLOAK_ADMIN_PASSWORD=admin           \// <2>
+    -p NAMESPACE=<PROJECT_NAME>                \// <3>
+| oc create -f -
+----
+<1> Replace `admin` with the user name you would like to use when accessing the Keycloak Administration Console.
+<2> Replace `admin` with the password you would like to use when accessing the Keycloak Administration Console.
+<3> Replace `<PROJECT_NAME>` with your project name.
+
+After running the above command, you should see the following output:
+
+[source,bash]
+----
+service/keycloak created
+route.route.openshift.io/keycloak created
+Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
+deploymentconfig.apps.openshift.io/keycloak created.
+----
+
+It will take a few minutes for OpenShift to provision the Keycloak pod and its related resources.
+
+You can use the OpenShift CLI or the OpenShift web console, depending on your preference, to check if your Keycloak server has been provisioned.
+
+=== OpenShift CLI
+
+To make sure your Keycloak server has been provisioned using the OpenShift CLI, run:
+
+[source,bash]
+----
+oc get pods
+----
+
+After a little while, check for a message similar to the following message that indicates the pod is ready:
+
+[source,bash]
+----
+NAME                READY     STATUS      RESTARTS   AGE
+keycloak-1-deploy   0/1       Completed   0          1h
+keycloak-1-l9kdx    1/1       Running     0          1h
+----
+
+Once the Keycloak server has been provisioned, use the following command to find the URL for your Keycloak instance's
+Admin Console:
+
+[source,bash]
+----
+KEYCLOAK_URL=https://$(oc get route keycloak --template='{{ .spec.host }}') &&
+echo "" &&
+echo "Keycloak Admin Console:   $KEYCLOAK_URL/admin" &&
+echo ""
+----
+
+=== OpenShift Web Console
+
+To make sure your Keycloak server has been provisioned using the OpenShift web console,
+navigate to the `Topology` view in the `Developer` perspective. You can click on your `keycloak` app
+to check its status. Once it is running, you can click on `Open URL` and then access Keycloak's `Administration Console`.

--- a/guides/security-oidc-auth0-openshift.adoc
+++ b/guides/security-oidc-auth0-openshift.adoc
@@ -1,0 +1,253 @@
+= Securing WildFly Apps with Auth0 on OpenShift
+:summary: Learn how to secure applications deployed to WildFly on OpenShift with the Auth0 OpenID provider.
+:includedir: _includes
+include::{includedir}/_attributes.adoc[]
+:prerequisites-time: 15
+
+You can secure your WildFly applications deployed on OpenShift with OpenID Connect (OIDC). By using OIDC to secure
+applications, you delegate authentication to OIDC providers. This guide shows how to secure an example application
+deployed to WildFly on OpenShift with OIDC using https://auth0.com/[Auth0] as the OpenID provider.
+
+If you prefer to watch a video, check out this 5-minute https://www.youtube.com/watch?v=uoQoCPGyAik[video] which also covers the steps
+from this guide.
+
+include::{includedir}/_prerequisites.adoc[]
+* Access to an OpenShift cluster (try the https://developers.redhat.com/developer-sandbox[Red Hat Developer Sandbox] for free)
+* https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
+* https://helm.sh/docs/intro/install/[Helm Chart]
+* Access to https://auth0.com/[Auth0]
+
+== Example Application
+
+We will use a simple web application in this guide that consists of a single https://github.com/wildfly-security-incubator/elytron-examples/blob/main/simple-webapp-auth0/src/main/java/org/wildfly/security/examples/SecuredServlet.java[servlet]. We will secure this servlet using OIDC.
+
+We will use the example in the https://github.com/wildfly-security-incubator/elytron-examples/tree/main/simple-webapp-auth0[simple-webapp-auth0] directory in the `elytron-examples` repo.
+
+To obtain this example, clone the `elytron-examples` repository to your local machine:
+
+[source,bash]
+----
+git clone git@github.com:wildfly-security-incubator/elytron-examples.git
+----
+
+include::{includedir}/_proc-log-into-openshift-cluster.adoc[]
+
+== Configure Auth0
+
+We will be using Auth0 as our OpenID provider.
+
+. Log into the *Auth0 Dashboard*.
+
+. Create an application called `OIDC App`. For the application type, select `Regular Web Applications` and then click on `Create`. For more information, see the Auth0 documentation on how to https://auth0.com/docs/get-started/auth0-overview/create-applications[create applications].
+
+. Once the application has been created, we'll see the `Domain`, `Client ID`, and `Client Secret` in the `Basic Information` section. We'll make use of these values when we <<add-helm-configuration>> later on.
+
+. Using the sidebar menu on the left side of the *Dashboard*, navigate to the `APIs` page and copy the `API Audience` value.
+
+. Using the sidebar menu on the left side of the *Dashboard*, navigate to the `Settings` page and scroll down to the `API Authorization Settings`. Paste the `API Audience` value you just copied into the `Default Audience` field and then click on `Save`.
+
++
+This will allow us to receive access tokens that are JWTs from Auth0. In the future, we're hoping to add the ability
+to handle opaque access tokens as well to WildFly's Elytron OIDC Client subsystem.
+
+. Using the sidebar menu on the left side of the *Dashboard*, click on `User Management` and then `Users`. You can then
+create a new user by clicking on `Create User`. You'll need to specify the new user's email, we'll use `user@example.com`. You'll also need to set a password for the user.
++
+Once the user has been created, you'll see the user's `user_id` at the top of the page.
++
+For more information, see Auth0's documentation on how to https://auth0.com/docs/manage-users/user-accounts/create-users[create users].
+
+[[add-helm-configuration]]
+== Add Helm Configuration
+
+. Switch to the `charts` directory in the `simple-webapp-auth0` example.
++
+[source,bash]
+----
+cd /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-auth0/charts
+----
++
+Notice there's a `helm.yaml` file in this directory with the following content:
++
+[source,yaml]
+----
+build:
+  uri: https://github.com/wildfly-security-incubator/elytron-examples.git
+  contextDir: simple-webapp-auth0
+deploy:
+  env:
+    - name: DOMAIN
+      value: <AUTH0_DOMAIN>             <1>
+    - name: CLIENT_ID
+      value: <AUTH0_CLIENT_ID>          <2>
+    - name: CLIENT_SECRET
+      value: <AUTH0_CLIENT_SECRET>      <3>
+----
+You need to update the environment variable values here using the information we saw earlier in the *Auth0 Dashboard*,
+as described below.
++
+<1> Replace `<AUTH0_DOMAIN>` with the `Domain` value from your OIDC App's `Basic Information` section in the *Auth0 Dashboard*.
+<2> Replace `<AUTH0_CLIENT_ID>` with the `Client ID` value from your OIDC App's `Basic Information` section in the *Auth0 Dashboard*.
+<3> Replace `<AUTH0_CLIENT_SECRET>` with the `Client Secret` value from your OIDC App's `Basic Information` section in the *Auth0 Dashboard*.
+
+== Deploy the Example Application to WildFly on OpenShift
+
+include::{includedir}/_proc-install-or-update-helm.adoc[]
+
+We can deploy our example application to WildFly on OpenShift using the WildFly Helm Chart:
+
+[source,bash]
+----
+helm install oidc-app -f /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-auth0/charts/helm.yaml wildfly/wildfly
+----
+
+Notice that this command specifies the file we updated, `helm.yaml`, that contains the values
+needed to build and deploy our application.
+
+include::{includedir}/_proc-follow-build-and-deployment-openshift.adoc[]
+
+=== Behind the Scenes
+
+While our application is building, let's take a closer look at our application.
+
+* Examine the  https://github.com/wildfly-security/elytron-examples/blob/main/simple-webapp-auth0/pom.xml[pom.xml] file.
++
+Notice that it contains an `openshift` profile. A profile in Maven lets you create a set of configuration values to customize your application build for different environments. The `openshift` profile in this example defines a configuration that will be used by the WildFly Helm Chart when provisioning the WildFly server on OpenShift.
++
+[source,xml]
+----
+<profiles>
+    <profile>
+        <id>openshift</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>         <!--1-->
+                    <version>${version.wildfly.maven.plugin}</version>
+                    <configuration>
+                        <feature-packs>
+                            <feature-pack>
+                                <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                            </feature-pack>
+                            <feature-pack>
+                                <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+                            </feature-pack>
+                        </feature-packs>
+                        <layers>
+                            <layer>cloud-server</layer>
+                            <layer>elytron-oidc-client</layer>            <!--2-->
+                        </layers>
+                        <filename>simple-webapp-auth0.war</filename>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>package</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+</profiles>
+----
+<1> `wildfly-maven-plugin` provisions a WildFly server with the specified layers with our application deployed.
+<2> `elytron-oidc-client` automatically adds the native OIDC client subsystem to our WildFly installation.
+
+* Examine the https://github.com/wildfly-security-incubator/elytron-examples/blob/main/simple-webapp-auth0/src/main/webapp/WEB-INF/web.xml[web.xml].
++
+[source,xml]
+----
+...
+    <login-config>
+        <auth-method>OIDC</auth-method>  <1>
+    </login-config>
+...
+----
++
+<1> When the `elytron-oidc-client` subsystem sees the `auth-method` is set to `OIDC`, it enables the OIDC authentication mechanism for the application.
+
+* Examine the https://github.com/wildfly-security-incubator/elytron-examples/blob/main/simple-webapp-auth0/src/main/webapp/WEB-INF/oidc.json[oidc.json] file. The `oidc.json` is used to configure the native OIDC client subsystem.
++
+[source,json]
+----
+{
+    "client-id" : "${env.CLIENT_ID}",                       <1>
+    "provider-url" : "https://${env.DOMAIN}",               <2>
+    "ssl-required" : "EXTERNAL",                            <3>
+    "credentials" : {
+        "secret" : "${env.CLIENT_SECRET}"                   <4>
+    }
+}
+----
++
+<1> The client ID, which is specified using the `CLIENT_ID` environment variable we defined in the Helm configuration.
+<2> The provider URL, which is specified using the `DOMAIN` environment variable. We defined its value in the Helm configuration.
+<3> When `ssl-required` is set to `EXTERNAL`, HTTPS is required by default for external requests.
+<4> The client secret is needed to communicate with Auth0. This refers to the `CLIENT_SECRET` environment variable that we defined in the Helm configuration.
+
+== Get the Application URL
+
+Once the WildFly server has been provisioned, use the following command to find the URL for your example
+application:
+
+[source,bash]
+----
+SIMPLE_WEBAPP_AUTH0_URL=https://$(oc get route oidc-app --template='{{ .spec.host }}') &&
+echo "" &&
+echo "Application URL: $SIMPLE_WEBAPP_AUTH0_URL/simple-webapp-auth0"  &&
+echo "Allowed Callback URL: $SIMPLE_WEBAPP_AUTH0_URL/simple-webapp-auth0/secured/*" &&
+echo ""
+----
+
+We'll make use of these URLs in the next two sections.
+
+== Finish Configuring Auth0
+
+From your `OIDC App` in the Auth0 Dashboard, scroll down to the `Application URIs` section and set
+`Allowed Callback URLs` to the `Allowed Callback URL` that was output in the previous section. Then click on `Save Changes`.
+
+== Access the Application
+
+From your browser, navigate to the `Application URL` that was output in the previous section.
+
+Click on `Access Secured Servlet`.
+
+You will be redirected to Auth0 to log in.
+
+Log in using the `user@example.com` user we created earlier.
+
+Upon successful authentication, you will be redirected back to the example application.
+
+The example application simply outputs the `user_id` of the logged in user.
+
+You should see output similar to the following:
+
+[source,text]
+----
+Secured Servlet
+
+Current Principal 'auth0|6544f9aa427fb9f276240d55'
+----
+
+Notice the `user_id` for our `user@example.com` user is displayed. This indicates that we have successfully logged into our application!
+
+== Next Steps
+
+This guide has shown how to secure an application deployed to WildFly on OpenShift using the Auth0 OpenID provider. For additional
+information, feel free to check out the resources linked below. To learn
+more about OIDC configuration, check out the https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OIDC Client]
+documentation.
+
+[[references]]
+== References
+
+* https://www.youtube.com/watch?v=uoQoCPGyAik[Vlog: Securing WildFly Apps with Auth0 on OpenShift]
+* https://auth0.com/docs/get-started[Getting started with Auth0]
+* https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OpenID Connect Client Subsystem Configuration]
+* https://docs.wildfly.org/{wildfly-version}/Getting_Started_on_OpenShift.html[Getting Started with WildFly on OpenShift]
+* https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
+* https://docs.wildfly.org/{wildfly-version}/Getting_Started_on_OpenShift.html#helm-charts[WildFly Helm Chart]
+* <<security-oidc-openshift.adoc#security-oidc-openshift,Securing WildFly Apps with OIDC on OpenShift>>

--- a/guides/security-oidc-identity-propagation.adoc
+++ b/guides/security-oidc-identity-propagation.adoc
@@ -1,0 +1,400 @@
+= Identity Propagation with OpenID Connect
+:summary: Learn how to propagate identities within a deployment and across deployments when securing WildFly apps with OpenID Connect.
+:includedir: _includes
+include::{includedir}/_attributes.adoc[]
+:prerequisites-time: 15
+
+When securing an application with OpenID Connect (OIDC), WildFly https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#virtual-security-2[automatically]
+creates and makes use of a virtual security domain across the deployment. If the application invokes an EJB, additional configuration
+might be required in order to propagate the security identity from the virtual security domain. The configuration that's needed
+depends on how the EJB that's being invoked is secured. This guide covers the different use cases for propagating an identity
+from a virtual security domain.
+
+include::{includedir}/_prerequisites.adoc[]
+* https://www.keycloak.org/guides#getting-started[Keycloak]
+
+== Overview of Identity Propagation with OIDC
+
+Additional configuration might be needed in order to propagate a security identity from a virtual security domain depending
+on how the EJB that's being invoked is secured.
+
+=== Securing an EJB using the Same OIDC Virtual Security Domain
+
+==== Within the Same Deployment
+
+If a web application secured with OIDC invokes an EJB within the same deployment (e.g., within the same WAR or EAR) and you'd
+like to secure the EJB using the same virtual security domain as the web application, no additional configuration is required.
+
+Both of examples that we'll be going through cover this use case.
+
+==== Across Deployments
+
+If a web application secured with OIDC invokes an EJB in a separate deployment (e.g., across EARs) and you'd like
+to secure the EJB using the same virtual security domain as the web application, the following configuration is needed:
+
+* A `virtual-security-domain` resource needs to be added in the Elytron subsystem.
+* The EJB being invoked needs to be updated with a `@SecurityDomain` annotation that references the `virtual-security-domain`.
+
+For a guided step by step example of how to configure this use case, see <<same-virtual-domain>>.
+
+[[different-security-domain]]
+=== Securing an EJB using a Different Security Domain
+
+If a web application secured with OIDC invokes an EJB (either in the same deployment or in a separate deployment) and
+you'd like to secure the EJB using a different security domain from the web application, the following configuration is
+needed:
+
+* A `virtual-security-domain` resource needs to be added in the Elytron subsystem.
+** This indicates the list of
+security domains that a virtual security domain should automatically outflow its security identities to.
+* A `trusted-virtual-security-domains` attribute needs to be configured for the `security-domain` that is being
+used to secure the EJB being invoked.
+** This indicates that the `security-domain` should trust any security identities
+that have been established by the specified virtual security domains.
+
+For a guided step by step example of how to configure this use case, see <<different-security-domain>>.
+
+== Example Applications
+
+We will use some simple web applications in this guide that consist of a servlet secured using OIDC. The servlet will invoke an EJB
+within the same deployment (i.e., invocation within the same EAR). This EJB will then invoke another EJB located in a different deployment
+(i.e., invocation across EARs).
+
+We will use the `oidc-with-identity-propagation` and `oidc-with-identity-propagation-same-domain` examples from the `elytron-examples` repository:
+
+* https://github.com/wildfly-security-incubator/elytron-examples/tree/main/oidc-with-identity-propagation[oidc-with-identity-propagation]
+* https://github.com/wildfly-security-incubator/elytron-examples/tree/main/oidc-with-identity-propagation-same-domain[oidc-with-identity-propagation-same-domain]
+
+To obtain the examples, clone the `elytron-examples` repository to your local machine:
+
+[source, shell]
+----
+git clone git@github.com:wildfly-security-incubator/elytron-examples.git
+----
+
+== Start Keycloak
+
+This guide will be making use of Keycloak as our OpenID provider.
+
+To start a Keycloak server in your environment, follow the appropriate guide for your environment
+from Keycloak’s https://www.keycloak.org/guides#getting-started[Getting Started] page.
+
+:add-role:
+include::{includedir}/_proc-configure-keycloak.adoc[]
+
+== Secure an EJB Invoked by an OIDC App using a Different Security Domain
+
+For this use case, we'll be using the https://github.com/wildfly-security-incubator/elytron-examples/tree/main/oidc-with-identity-propagation[oidc-with-identity-propagation] example.
+
+=== Inspect the Example Applications
+
+Let's take a closer look at our example.
+
+* This example consists of two EARs when built: `virtual-security-domain-to-domain.ear` and `ejb-basic.ear`.
+
+* Notice that `virtual-security-domain-to-domain.ear` contains a https://github.com/wildfly-security-incubator/elytron-examples/tree/main/oidc-with-identity-propagation/virtual-security-domain-to-domain/web/src/main/java/org/wildfly/security/examples/virtual_security_domain_to_domain/web/SecuredServlet.java[servlet]
+that invokes an EJB, https://github.com/wildfly-security-incubator/elytron-examples/tree/main/oidc-with-identity-propagation/virtual-security-domain-to-domain/ejb/src/main/java/org/wildfly/security/examples/virtual_security_domain_to_domain/ejb/EntryBean.java[EntryBean],
+that's also contained in the same EAR. This EJB doesn't have any explicit security domain configuration. Thus, this EJB will automatically be secured using the same virtual security domain as the servlet.
+
+* The `EntryBean` invokes another EJB, https://github.com/wildfly-security-incubator/elytron-examples/tree/main/oidc-with-identity-propagation/ejb-basic/ejb/src/main/java/org/wildfly/security/examples/ejb_basic/ejb/ManagementBean.java[ManagementBean], that's part of `ejb-basic.ear`.
+Notice that `ManagementBean` has a `@SecurityDomain("BusinessDomain")` annotation.
+
+* Because the `ManagementBean` is being secured using a security domain that's different from the virtual security domain that's being
+used to secure the web application, we'll need to add configuration to propagate security identities from the virtual security domain to
+the `BusinessDomain`.
+
+=== Start WildFly
+
+First, we need to start our WildFly instance. We'll specify a port offset since our Keycloak instance is exposed on
+port 8080:
+
+[source,bash]
+----
+./bin/standalone.sh -Djboss.socket.binding.port-offset=10
+----
+
+=== Configure the Security Domain that will be used to Secure the EJB (BusinessDomain)
+
+We're going to secure the EJB being invoked with a security domain called `BusinessDomain`. To create this security domain,
+we'll connect to the WildFly CLI and execute the CLI commands shown below.
+
+[source,bash]
+----
+./bin/jboss-cli.sh --connect --controller=localhost:10000
+----
+
+[source,bash]
+----
+
+# Add a filesystem realm called BusinessRealm in the jboss.server.config directory
+/subsystem=elytron/filesystem-realm=BusinessRealm:add(path=business-realm-users,relative-to=jboss.server.config.dir)
+
+# Add user alice with Admin role
+/subsystem=elytron/filesystem-realm=BusinessRealm:add-identity(identity=alice)
+/subsystem=elytron/filesystem-realm=BusinessRealm:add-identity-attribute(identity=alice, name=Roles, value=["Admin"])
+
+# Add a security domain that references our newly created realm
+/subsystem=elytron/security-domain=BusinessDomain:add(realms=[{realm=BusinessRealm}],default-realm=BusinessRealm,permission-mapper=default-permission-mapper)
+
+# Update the application security domain mapping in the EJB3 subsystem
+/subsystem=ejb3/application-security-domain=BusinessDomain:add(security-domain=BusinessDomain)
+
+reload
+----
+
+=== Configure Identity Propagation
+
+First, let's configure a `virtual-security-domain` in the Elytron subsystem to specify that we want to automatically
+outflow any security identities established by the virtual security domain to the `BusinessDomain`:
+
+[source,bash]
+----
+/subsystem=elytron/virtual-security-domain=virtual-security-domain-to-domain.ear:add(outflow-security-domains=[BusinessDomain])
+----
+
+Next, let's update the `BusinessDomain` to specify that we want to trust any security identities established by the virtual
+security domain associated with `virtual-security-domain-to-domain.ear`:
+
+[source,bash]
+----
+/subsystem=elytron/security-domain=BusinessDomain:write-attribute(name=trusted-virtual-security-domains, value=[virtual-security-domain-to-domain.ear])
+----
+
+Finally, let's execute a reload:
+
+[source,bash]
+----
+reload
+----
+
+=== Deploy the Example Application to WildFly
+
+We're now going to build and deploy our example.
+
+From the `elytron-examples` directory, run the following commands to build and deploy the `ejb-basic.ear` and `virtual-security-domain-to-domain.ear`:
+
+[source,bash]
+----
+cd YOUR_PATH_TO_ELYTRON_EXAMPLES/oidc-with-identity-propagation/ejb-basic
+mvn clean install wildfly:deploy -Dwildfly.port=10000
+----
+
+[source,bash]
+----
+cd YOUR_PATH_TO_ELYTRON_EXAMPLES/oidc-with-identity-propagation/virtual-security-domain-to-domain
+mvn clean install wildfly:deploy -Dwildfly.port=10000
+----
+
+=== Finish Configuring Keycloak
+
+From your `myclient` client in the Keycloak Administration Console,
+in the client settings, set `Valid redirect URIs` to http://localhost:8090/virtual-security-domain-to-domain/secured and then click `Save`.
+
+=== Access the Application
+
+From your browser, navigate to http://localhost:8090/virtual-security-domain-to-domain.
+
+Click on `Access Secured Servlet`.
+
+You will be redirected to Keycloak to log in.
+
+Log in using the `alice` user we created earlier.
+
+Upon successful authentication, you will be redirected back to the example application.
+
+The example application outputs information about the user.
+
+You should see the following output:
+
+[source,text]
+----
+Successfully logged into Secured Servlet with OIDC
+
+Identity as visible to servlet.
+
+Principal : alice
+
+Authentication Type : OIDC
+
+Caller Has Role 'User'=true
+
+Caller Has Role 'Admin'=false
+
+Identity as visible to EntryBean.
+
+Principal : alice
+
+Caller Has Role 'User'=true
+
+Caller Has Role 'Admin'=false
+
+Identity as visible to ManagementBean.
+
+Principal : alice
+
+Caller Has Role 'User'=false
+
+Caller Has Role 'Admin'=true
+----
+
+Notice the following things:
+
+* The identity as visible to the servlet and the EJB within `virtual-security-domain-to-domain.ear` is `alice` with `User` role. This
+shows that the identity from the virtual security domain was successfully propagated to the EJB within the same EAR.
+
+* The identity as visible to the EJB within `ejb-basic.ear` is `alice` with `Admin` role. This shows that the identity
+from the virtual security domain was successfully propagated to the `BusinessDomain` that's used to secure the EJB
+in a separate deployment.
+
+[[same-virtual-domain]]
+== Secure an EJB Invoked by an OIDC App using the Same Virtual Security Domain
+
+For this use case, we'll be using the https://github.com/wildfly-security-incubator/elytron-examples/tree/main/oidc-with-identity-propagation-same-domain[oidc-with-identity-propagation-same-domain] example.
+
+=== Inspect the Example Applications
+
+Let's take a closer look at our example.
+
+* This example consists of two EARs when built: `same-virtual-domain.ear` and `ejb-same-domain.ear`.
+
+* Notice that `same-virtual-domain.ear` contains a https://github.com/wildfly-security-incubator/elytron-examples/blob/main/oidc-with-identity-propagation-same-domain/same-virtual-domain/web/src/main/java/org/wildfly/security/examples/same_virtual_domain/web/WhoAmIServlet.java[servlet]
+that invokes an EJB, https://github.com/wildfly-security-incubator/elytron-examples/blob/main/oidc-with-identity-propagation-same-domain/same-virtual-domain/ejb/src/main/java/org/wildfly/security/examples/same_virtual_domain/ejb/EntryBean.java[EntryBean],
+that's also contained in the same EAR. This EJB doesn't have any explicit security domain configuration. Thus, this EJB will automatically be secured using the same virtual security domain as the servlet.
+
+* The `EntryBean` invokes another EJB, https://github.com/wildfly-security-incubator/elytron-examples/blob/main/oidc-with-identity-propagation-same-domain/ejb-same-domain/ejb/src/main/java/org/wildfly/security/examples/ejb_same_domain/ejb/WhoAmIBean.java[WhoAmIBean], that's part of `ejb-same-domain.ear`.
+
+* Because we want to secure the `WhoAmIBean` with the same virtual security domain that's being
+used to secure the web application, we'll need to add configuration to accomplish this.
+
+=== Start WildFly
+
+First, we need to start our WildFly instance. We'll specify a port offset since our Keycloak instance is exposed on
+port 8080:
+
+[source,bash]
+----
+./bin/standalone.sh -Djboss.socket.binding.port-offset=10
+----
+
+=== Configure the Virtual Security Domain that will be used to Secure the EJB
+
+We're going to secure the EJB being invoked with the same virtual security domain that's being used
+to secure the web application with OIDC. We first need to connect to the WildFly CLI and add a `virtual-security-domain`
+resource in the Elytron subsystem as follows:
+
+[source,bash]
+----
+./bin/jboss-cli.sh --connect --controller=localhost:10000
+----
+
+[source,bash]
+----
+# Add a virtual security domain resource for the same-virtual-domain.ear application
+/subsystem=elytron/virtual-security-domain=same-virtual-domain.ear:add()
+----
+
+=== Configure Identity Propagation
+
+Next, let's update the `WhoAmIBean` to indicate that we want to secure it using the same virtual domain
+that's being used to secure `same-virtual-domain.ear`:
+
+[source,java]
+----
+@SecurityDomain("same-virtual-domain.ear")
+public class WhoAmIBean implements WhoAmI {
+    ...
+}
+----
+
+=== Deploy the Example Application to WildFly
+
+We're going to build and deploy our example.
+
+From the `elytron-examples` directory, run the following commands to build and deploy the `ejb-same-domain.ear` and `same-virtual-domain.ear`:
+
+[source,bash]
+----
+cd YOUR_PATH_TO_ELYTRON_EXAMPLES/oidc-with-identity-propagation-same-domain/ejb-same-domain
+mvn clean install wildfly:deploy -Dwildfly.port=10000
+----
+
+[source,bash]
+----
+cd YOUR_PATH_TO_ELYTRON_EXAMPLES/oidc-with-identity-propagation-same-domain/same-virtual-domain
+mvn clean install wildfly:deploy -Dwildfly.port=10000
+----
+
+=== Finish Configuring Keycloak
+
+From your `myclient` client in the Keycloak Administration Console,
+in the client settings, set `Valid redirect URIs` to http://localhost:8090/same-virtual-domain/secured and then click `Save`.
+
+=== Access the Application
+
+From your browser, navigate to http://localhost:8090/same-virtual-domain.
+
+Click on `Access Secured Servlet`.
+
+You will be redirected to Keycloak to log in.
+
+Log in using the `alice` user we created earlier.
+
+Upon successful authentication, you will be redirected back to the example application.
+
+The example application outputs information about the user.
+
+You should see the following output:
+
+[source,text]
+----
+Successfully logged into Secured Servlet with OIDC
+
+Identity as visible to servlet.
+
+Principal : alice
+
+Authentication Type : OIDC
+
+Caller Has Role 'User'=true
+
+Caller Has Role 'Admin'=false
+
+Identity as visible to EntryBean.
+
+Principal : alice
+
+Caller Has Role 'User'=true
+
+Caller Has Role 'Admin'=false
+
+Identity as visible to ManagementBean.
+
+Principal : alice
+
+Caller Has Role 'User'=true
+
+Caller Has Role 'Admin'=false
+----
+
+Notice the following things:
+
+* The identity as visible to the servlet and the EJB within `same-virutal-domain.ear` is `alice` with `User` role. This
+shows that the identity from the virtual security domain was successfully propagated to the EJB within the same EAR.
+
+* The identity as visible to the EJB within `ejb-same-domain.ear` is `alice` with `User` role. This shows that the identity
+from the virtual security domain was successfully propagated to the EJB in a separate deployment.
+
+== Next Steps
+
+This guide shown how to propagate security identities established by a virtual security domain within a deployment
+and across deployments when securing a web application with OIDC. To learn
+more about OIDC configuration, check out the https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OIDC Client]
+documentation.
+
+[[references]]
+== References
+
+* https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#identity_propagation[OIDC Identity Propagation]
+* https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OpenID Connect Client Subsystem Configuration]
+* https://www.keycloak.org/docs/latest/server_admin/index.html[Keycloak Server Administration Guide]
+* <<security-oidc-openshift.adoc#security-oidc-openshift,Securing WildFly Apps with OIDC on OpenShift>>

--- a/guides/security-oidc-management-console.adoc
+++ b/guides/security-oidc-management-console.adoc
@@ -1,0 +1,128 @@
+= Securing the WildFly Management Console with OpenID Connect
+:summary: Learn how to secure the WildFly management console with the Keycloak OpenID provider.
+:includedir: _includes
+include::{includedir}/_attributes.adoc[]
+:prerequisites-time: 15
+
+You can secure the WildFly Management Console with OpenID Connect (OIDC) using the Keycloak
+OpenID provider. When the WildFly Management Console is secured using OIDC, this means that when a user attempts to
+access the console, they will be redirected to the Keycloak OpenID provider's login page. Upon successful
+authentication, the user will then be redirected back to the WildFly Management Console. This guide
+explains how to configure this.
+
+include::{includedir}/_prerequisites.adoc[]
+* https://www.keycloak.org/guides#getting-started[Keycloak]
+
+== Start Keycloak
+
+This guide will be making use of Keycloak as our OpenID provider.
+
+To start a Keycloak server in your environment, follow the appropriate guide for your environment
+from Keycloak’s https://www.keycloak.org/guides#getting-started[Getting Started] page.
+
+== Configure Keycloak
+
+. Log into the `Keycloak Admin Console`.
+
+. Create a new realm called `wildfly-infra`. For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-a-realm_server_administration_guide[create a realm].
+
+. Create a new client as follows:
+* `General Settings`:
+** *Client type* (or *Client Protocol*, depending on your Keycloak version): `OpenID Connect`
+** *Client ID*: `wildfly-console`
+* `Capability config`:
+** *Authentication flow*: `Standard flow`, `Direct access grants`
+* `Login settings`:
+** Set the *Valid redirect URIs* using the URI that will be used to access the WildFly Management Console.
+Since we will use a port offset of 10 when starting WildFly in this guide, we will set the `Valid redirect URIs` to http://localhost:10000/console/*.
+** Set the *Web Origins* using the management port for our WildFly instance, e.g., http://localhost:10000.
+
++
+For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#_oidc_clients[Manage OpenID Connect clients].
+
+. Click `Save` to save the client.
+
+. Create a second new client as follows:
+* `General Settings`:
+** *Client type* (or *Client Protocol*, depending on your Keycloak version): `OpenID Connect`
+** *Client ID*: `wildfly-management`
+* *Capability config*:
+** *Authentication flow*: This client will be a bearer-only client, be sure to *uncheck* `Standard flow` and *uncheck* `Direct access grants`.
+* *Login settings*: Leave the fields blank.
+
++
+For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#_oidc_clients[Manage OpenID Connect clients].
+
+. Click `Save` to save the client.
+
+. *[Optional]* If you want to configure WildFly to use https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#RBAC[Role Based Access Control], add a role called `Administrator`. For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#assigning-permissions-using-roles-and-groups[create a role].
+
+. Add a new user named `alice`. For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-user_server_administration_guide[create a user].
+
+. Once the new user has been created, set a password for this new user from the `Credentials` tab.
+
+. *[Optional]* If you want to configure WildFly to use https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#RBAC[Role Based Access Control], from the `Role Mapping` tab, assign `alice` the `Administrator` role. For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#proc-assigning-role-mappings_server_administration_guide[assign a role] to a user.
+
+== Configure Elytron OIDC Client
+
+Now that we've configured our OpenID provider, there are a couple things that need to be configured in the
+`elytron-oidc-client` subsystem to secure the WildFly Management Console with OIDC.
+
+First, we need to add a `secure-deployment` resource that references the `wildfly-management` client that was created in the previous section.
+
+A `secure-server` that references the `wildfly-console` client is also needed.
+
+We can use the following commands to add the required configuration:
+
+First, we need to start our WildFly server instance. Notice that we're specifying a port offset here
+since our Keycloak instance is already exposed on port 8080:
+
+[source,bash]
+----
+./bin/standalone.sh -Djboss.socket.binding.port-offset=10
+----
+
+Next, we can connect to the WildFly CLI and then execute the commands below:
+
+[source,bash]
+----
+./bin/jboss-cli.sh --connect --controller=localhost:10000
+----
+
+[source,shell]
+----
+# Configure the Keycloak provider
+/subsystem=elytron-oidc-client/provider=keycloak:add(provider-url=http://localhost:8080/realms/wildfly-infra)
+
+# Create a secure-deployment in order to secure the management interface with bearer token authentication
+/subsystem=elytron-oidc-client/secure-deployment=wildfly-management:add(provider=keycloak,client-id=wildfly-management,principal-attribute=preferred_username,bearer-only=true,ssl-required=EXTERNAL)
+
+# (Optional) Enable RBAC where roles are obtained from the identity
+/core-service=management/access=authorization:write-attribute(name=provider,value=rbac)
+/core-service=management/access=authorization:write-attribute(name=use-identity-roles,value=true)
+
+# Create a secure-server to ensure that the WildFly Management Console will redirect to the Keycloak OpenID provider for log in
+/subsystem=elytron-oidc-client/secure-server=wildfly-console:add(provider=keycloak,client-id=wildfly-console,public-client=true)
+
+reload
+----
+
+== Accessing the WildFly Management Console
+
+With the above configuration now in place, let's access http://localhost:10000/console. We will be redirected to
+the Keycloak login page. We can log in using the `alice` user that we created earlier. Upon successful authentication,
+we will be redirected back to the WildFly Management Console.
+
+== Next Steps
+
+This guide has shown how to secure the WildFly Management Console with OIDC. To learn
+more about OIDC configuration, check out the https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OIDC Client]
+documentation.
+
+[[references]]
+== References
+
+* https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OpenID Connect Client Subsystem Configuration]
+* https://www.keycloak.org/guides#getting-started[Getting Started with Keycloak]
+* https://www.keycloak.org/docs/latest/server_admin/index.html[Keycloak Server Administration Guide]
+* <<security-oidc-openshift.adoc#security-oidc-openshift,Securing WildFly Apps with OIDC on OpenShift>>

--- a/guides/security-oidc-openshift.adoc
+++ b/guides/security-oidc-openshift.adoc
@@ -1,0 +1,227 @@
+[[security-oidc-openshift]]
+= Securing WildFly Apps with OIDC on OpenShift
+:summary: Learn how to secure applications deployed to WildFly on OpenShift with OpenID Connect.
+:includedir: _includes
+include::{includedir}/_attributes.adoc[]
+:prerequisites-time: 15
+
+You can secure your WildFly applications deployed on OpenShift with OpenID Connect (OIDC). By using OIDC
+to secure applications, you delegate authentication to OIDC providers. This guide shows how to secure an
+example application deployed to WildFly on OpenShift with OIDC using Keycloak as the OpenID provider.
+
+include::{includedir}/_prerequisites.adoc[]
+* Access to an OpenShift cluster (try the https://developers.redhat.com/developer-sandbox[Red Hat Developer Sandbox] for free)
+* https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
+* https://helm.sh/docs/intro/install/[Helm Chart]
+
+== Example Application
+
+We will use a simple web application in this guide that consists of a single https://github.com/wildfly-security-incubator/elytron-examples/blob/main/simple-webapp-oidc/src/main/java/org/wildfly/security/examples/SecuredServlet.java[servlet]. We will secure this servlet using OIDC.
+
+We will use the example in the https://github.com/wildfly-security-incubator/elytron-examples/tree/main/simple-webapp-oidc[simple-webapp-oidc] directory in the `elytron-examples` repo.
+
+To obtain this example, clone the `elytron-examples` repository to your local machine:
+
+[source,bash]
+----
+git clone git@github.com:wildfly-security-incubator/elytron-examples.git
+----
+
+include::{includedir}/_proc-log-into-openshift-cluster.adoc[]
+
+include::{includedir}/_proc-start-keycloak-openshift.adoc[]
+
+include::{includedir}/_proc-configure-keycloak.adoc[]
+
+== Add Helm Configuration
+
+. Obtain the URL for Keycloak.
++
+[source,bash]
+----
+KEYCLOAK_URL=https://$(oc get route keycloak --template='{{ .spec.host }}') &&
+echo "" &&
+echo "Keycloak URL:   $KEYCLOAK_URL" &&
+echo ""
+----
+
+. Switch to the `charts` directory in the `simple-webapp-oidc` example.
++
+[source.bash]
+----
+cd /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-oidc/charts
+----
++
+Notice there's a `helm.yaml` file in this directory with the following content:
++
+[source,yaml]
+----
+build:
+  uri: https://github.com/wildfly-security-incubator/elytron-examples.git
+  contextDir: simple-webapp-oidc
+deploy:
+  replicas: 1
+  env:
+    - name: OIDC_PROVIDER_URL
+      value: <KEYCLOAK_URL>    <1>
+----
+<1> Replace `<KEYCLOAK_URL>` with the Keycloak URL obtained in the previous command.
+
+== Deploy the Example Application to WildFly on OpenShift
+
+include::{includedir}/_proc-install-or-update-helm.adoc[]
+
+We can deploy our example application to WildFly on OpenShift using the WildFly Helm Chart:
+
+[source,bash]
+----
+helm install oidc-app -f /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-oidc/charts/helm.yaml wildfly/wildfly
+----
+
+Notice that this command specifies the file we updated, `helm.yaml`, that contains the values
+needed to build and deploy our application.
+
+include::{includedir}/_proc-follow-build-and-deployment-openshift.adoc[]
+
+=== Behind the Scenes
+
+While our application is building, let's take a closer look at our application.
+
+* Examine the  https://github.com/wildfly-security/elytron-examples/blob/main/simple-webapp-oidc/pom.xml[pom.xml] file.
++
+Notice that it contains an `openshift` profile. A profile in Maven lets you create a set of configuration values to customize your application build for different environments.
+The `openshift` profile in this example defines a configuration that will be used by the WildFly Helm Chart when provisioning the WildFly server on OpenShift.
++
+[source,xml]
+----
+<profiles>
+    <profile>
+        <id>openshift</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>         <!--1-->
+                    <version>${version.wildfly.maven.plugin}</version>
+                    <configuration>
+                        <feature-packs>
+                            <feature-pack>
+                                <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                            </feature-pack>
+                            <feature-pack>
+                                <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+                            </feature-pack>
+                        </feature-packs>
+                        <layers>
+                            <layer>cloud-server</layer>
+                            <layer>elytron-oidc-client</layer>             <!--2-->
+                        </layers>
+                        <filename>simple-webapp-oidc.war</filename>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>package</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+</profiles>
+----
+<1> `wildfly-maven-plugin` provisions a WildFly server with the specified layers with our application deployed.
+<2> `elytron-oidc-client` automatically adds the native OIDC client subsystem to our WildFly installation.
+
+* Examine the https://github.com/wildfly-security-incubator/elytron-examples/blob/main/simple-webapp-oidc/src/main/webapp/WEB-INF/web.xml[web.xml].
++
+[source,xml,options="nowrap"]
+----
+...
+    <login-config>
+        <auth-method>OIDC</auth-method>  <1>
+    </login-config>
+...
+----
+<1> When `elytron-oidc-client` subsystem sees `auth-method` is set to `OIDC`, it enables OIDC authentication mechanism for the application.
+
+* Examine the https://github.com/wildfly-security-incubator/elytron-examples/blob/main/simple-webapp-oidc/src/main/webapp/WEB-INF/oidc.json[oidc.json] file. The `oidc.json` is used to configure the native OIDC client subsystem.
++
+[source,json,options="nowrap"]
+----
+{
+    "client-id" : "myclient",                                                         <1>
+    "provider-url" : "${env.OIDC_PROVIDER_URL:http://localhost:8080}/realms/myrealm", <2>
+    "public-client" : "true",                                                         <3>
+    "principal-attribute" : "preferred_username",                                     <4>
+    "ssl-required" : "EXTERNAL"                                                       <5>
+}
+----
+<1> This is the client we created in Keycloak.
+<2> The provider URL, which is the URL for the realm `myrealm` that we created, is specified as an environment variable. We will set its value in the Helm configuration.
+<3> When `public-client` is set to `true`, client credentials are not sent when communicating with the OpenID provider.
+<4> We specify that the user name of the identity, which in our case is `alice`, is to be used as the principal for the identity.
+<5> When `ssl-required` is set to `EXTERNAL`, HTTPS is required by default for external requests.
+
+== Get the Application URL
+
+Once the WildFly server has been provisioned, use the following command to find the URL for your example
+application:
+
+[source,bash]
+----
+SIMPLE_WEBAPP_OIDC_URL=https://$(oc get route oidc-app --template='{{ .spec.host }}') &&
+echo "" &&
+echo "Application URL: $SIMPLE_WEBAPP_OIDC_URL/simple-webapp-oidc"  &&
+echo "Valid redirect URI: $SIMPLE_WEBAPP_OIDC_URL/simple-webapp-oidc/secured/*" &&
+echo ""
+----
+
+We'll make use of these URLs in the next two sections.
+
+== Finish Configuring Keycloak
+
+From your `myclient` client in the Keycloak Administration Console,
+in the client settings, set `Valid redirect URIs` to the Valid redirect URI that was output in the previous section and then click `Save`.
+
+== Access the Application
+
+From your browser, navigate to the `Application URL` that was output in the previous section.
+
+Click on `Access Secured Servlet`.
+
+You will be redirected to Keycloak to log in.
+
+Log in using the `alice` user we created earlier.
+
+Upon successful authentication, you will be redirected back to the example application.
+
+The example application simply outputs the name of the logged in user.
+
+You should see the following output:
+
+[source,text]
+----
+Secured Servlet
+
+Current Principal 'alice'
+----
+
+This indicates that we have successfully logged into our application!
+
+== Next Steps
+
+This guide has shown how to secure an application deployed to WildFly on OpenShift with OIDC. To learn
+more about OIDC configuration, check out the https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OIDC Client]
+documentation.
+
+[[references]]
+== References
+
+* https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OpenID Connect Client Subsystem Configuration]
+* https://docs.wildfly.org/{wildfly-version}/Getting_Started_on_OpenShift.html[Getting Started with WildFly on OpenShift]
+* https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
+* https://docs.wildfly.org/{wildfly-version}/Getting_Started_on_OpenShift.html#helm-charts[WildFly Helm Chart]
+* https://www.keycloak.org/getting-started/getting-started-openshift[Getting started with Keycloak on OpenShift]
+* https://www.keycloak.org/docs/latest/server_admin/index.html[Keycloak Server Administration Guide]

--- a/guides/security-saml-openshift.adoc
+++ b/guides/security-saml-openshift.adoc
@@ -1,0 +1,276 @@
+= Securing WildFly Apps with SAML on OpenShift
+:summary: Learn how to secure applications deployed to WildFly on OpenShift with SAML.
+:includedir: _includes
+include::{includedir}/_attributes.adoc[]
+:prerequisites-time: 15
+
+You can secure your WildFly applications deployed on OpenShift with Security Assertion Markup Language (SAML).
+By using SAML to secure applications, you delegate authentication to SAML identity providers (IdPs). This guide shows
+how to secure an example application deployed to WildFly on OpenShift with SAML using Keycloak as the SAML IdP.
+
+include::{includedir}/_prerequisites.adoc[]
+* Access to an OpenShift cluster (try the https://developers.redhat.com/developer-sandbox[Red Hat Developer Sandbox] for free)
+* https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
+* https://helm.sh/docs/intro/install/[Helm Chart]
+
+== Example Application
+
+We will use a simple web application in this guide that consists of a single https://github.com/wildfly-security-incubator/elytron-examples/blob/main/simple-webapp-saml/src/main/java/org/wildfly/security/examples/SecuredServlet.java[servlet]. We will secure this servlet using SAML.
+
+We will use the example in the https://github.com/wildfly-security-incubator/elytron-examples/tree/main/simple-webapp-saml[simple-webapp-saml] directory in the `elytron-examples` repo.
+
+To obtain this example, clone the `elytron-examples` repository to your local machine:
+
+[source,bash]
+----
+git clone git@github.com:wildfly-security-incubator/elytron-examples.git
+----
+
+include::{includedir}/_proc-log-into-openshift-cluster.adoc[]
+
+:saml-auth-method:
+include::{includedir}/_proc-start-keycloak-openshift.adoc[]
+
+== Configure Keycloak
+
+. Log into the `Keycloak Admin Console`.
+
+. Create a new realm called `myrealm`. For more information, see the Keycloak documentation on how to https://www.keycloak.org/getting-started/getting-started-openshift#_create_a_realm[create a realm].
+
+. Add a role called `user`. This role will be required to access our simple web application. For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#assigning-permissions-using-roles-and-groups[create a role].
+
+. Add a new user named `alice`. Set an `email` address for this new user, we'll use `alice@example.org`. For more information, see the Keycloak documentation on how to https://www.keycloak.org/getting-started/getting-started-openshift#_create_a_user[create a user].
+
+. Once the new user has been created, set a password for this new user from the `Credentials` tab.
+
+. From the `Role Mapping` tab, assign `alice` the `user` role. For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#proc-assigning-role-mappings_server_administration_guide[assign a role] to a user.
+
+. Create a new client as follows:
+* `General Settings`:
+** *Client type* (or *Client Protocol*, depending on your Keycloak version): `SAML`
+** *Client ID*: `simple-webapp-saml`
+* `Login settings`: Leave the fields blank for now.
+
++
+For more information, see the Keycloak documentation on how to https://www.keycloak.org/docs/latest/server_admin/index.html#_client-saml-configuration[Create SAML clients].
+
+. Click `Save` to save the client.
+
+. Once the new client has been created, in the `Settings` tab, scroll down to the `SAML capabilities` section and
+set the `Name ID format` to `email`. When accessing
+our servlet later on, we will see that this results in `HttpServletRequest.getUserPrincipal().getName()` returning
+the logged in user's email address.
+
+. Then set `Force name ID format` to `On`. Then click on `Save`.
+
+== Download the SAML Keys
+
+. From your `simple-webapp-saml` client in the Keycloak Admin Console, click on the `Keys` tab.
+
+. Click on the `Export` button in the `Signing keys config` to export the SAML keys to a keystore.
+
+. Set the *Key alias* to `simple-webapp-saml`, the *Key password* to `password`,
+the *Realm certificate alias* to `myrealm`, and the *Store password* to `password`.
++
+Take note of the aliases and passwords that you specify here since these will be used
+when updating the `keycloak-saml.xml` file.
+
+. Click on `Export` to download the corresponding `keystore.jks` file.
+
+. Create an OpenShift secret using this keystore by running the following command:
++
+[source,bash]
+----
+oc create secret generic simple-webapp-saml-secret --from-file=/PATH/TO/keystore.jks
+----
+
+== Download and Edit the Keycloak Adapter Configuration File
+
+. From your `simple-webapp-saml` client in the *Keycloak Admin Console*, click on the `Action` dropdown in the top right corner
+and select `Download Adapter Config`.
+
+. For the `Format option`, select the `Keycloak SAML Adapter keycloak-saml.xml`, and download the file and place it in the example
+application's `WEB-INF` directory, i.e., place the `keycloak-saml.xml` file in
+`/PATH/TO/ELYTRON/EXAMPLES/simple-webapp-saml/src/main/webapp/WEB-INF`.
+
+. Update the `keycloak-saml.xml` file as follows:
+
+* Set the *SP* *entityID* to `"simple-webapp-saml"`
+* Set the *SP* *logoutPage* to `"/simple-webapp-saml"`
+* Replace the *SP* *Keys* configuration with the following configuration, being sure to use the aliases
+and passwords you specified when exporting the SAML keys to the `keystore.jks` file:
++
+[source,xml]
+----
+<Keys>
+    <Key signing="true">
+        <KeyStore password="password" file="/etc/keycloak-saml-secret-volume/keystore.jks">
+            <PrivateKey alias="simple-webapp-saml" password="password"/>
+            <Certificate alias="myrealm"/>
+        </KeyStore>
+    </Key>
+</Keys>
+----
++
+* Push this new file to the `simple-webapp-saml` directory in your `elytron-examples` fork, making
+sure to push the changes to your fork's default branch.
++
+[source,bash]
+----
+cd /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-saml
+git add src/main/webapp/WEB-INF/keycloak-saml.xml
+git commit -m "Added Keycloak adapter deployment descriptor file"
+git push origin main
+----
+
+== Add Helm Configuration
+
+Let's switch to the `charts` directory in our `simple-webapp-saml` example:
+
+[source,bash]
+----
+cd /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-saml/charts
+----
+
+Notice there's a `helm.yaml` file in this directory with the following content:
+
+[source,yaml]
+----
+build:
+  uri: https://github.com/YOUR_GITHUB_USERNAME/elytron-examples       <1>
+  contextDir: simple-webapp-saml
+deploy:
+  volumes:
+    - name: saml-keystore-volume
+      secret:
+        secretName: simple-webapp-saml-secret
+  volumeMounts:
+    - name: saml-keystore-volume
+      mountPath: /etc/keycloak-saml-secret-volume
+      readOnly: true
+----
+<1> Replace `YOUR_GITHUB_USERNAME` in the *build* *uri* with your own GitHub username.
+
+The `helm.yaml` file specifies the Git repository that contains our application's source code.
+
+Because we have modified the application's source code by adding a `keycloak-saml.xml` file, you need
+to set the *build* *uri* in the `helm.yaml` file to point to your own fork.
+
+Notice that our `helm.yaml` file also refers to the OpenShift secret, `simple-webapp-saml-secret` we
+created earlier. This will be used to mount the `keystore.jks` file on our WildFly server pod.
+
+== Deploy the Example Application to WildFly on OpenShift
+
+We can deploy our example application to WildFly on OpenShift using the WildFly Helm Chart:
+
+[source,bash]
+----
+helm install saml-app -f /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-saml/charts/helm.yaml wildfly/wildfly
+----
+
+Notice that this command specifies the file we updated, `helm.yaml`, that contains the values
+needed to build and deploy our application.
+
+include::{includedir}/_proc-follow-build-and-deployment-openshift.adoc[]
+
+=== Behind the Scenes
+
+While our application is building, let's take a closer look at our application's https://github.com/wildfly-security/elytron-examples/blob/main/simple-webapp-saml/pom.xml[pom.xml] file.
+Notice that it contains the following `wildfly-maven-plugin` configuration:
+
+[source,xml]
+----
+<plugin>
+    <groupId>org.wildfly.plugins</groupId>
+    <artifactId>wildfly-maven-plugin</artifactId>
+    <version>${version.wildfly.plugin}</version>
+    <configuration>
+        <feature-packs>
+            <feature-pack>
+                <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+            </feature-pack>
+            <feature-pack>
+                <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+            </feature-pack>
+            <feature-pack>
+                <location>org.keycloak:keycloak-saml-adapter-galleon-pack:${version.keycloak}</location>
+            </feature-pack>
+        </feature-packs>
+        <layers>
+            <layer>cloud-server</layer>
+            <layer>keycloak-client-saml</layer>
+        </layers>
+    </configuration>
+    <executions>
+        <execution>
+            <goals>
+                <goal>package</goal>
+            </goals>
+        </execution>
+    </executions>
+ </plugin>
+----
+
+This configuration is used to provision a WildFly server with the specified layers and with our application deployed.
+
+The `keycloak-client-saml` layer automatically adds the Keycloak SAML adapter to our WildFly installation.
+
+== Get the Application URL
+
+Once the WildFly server has been provisioned, use the following command to find the URL for your example
+application:
+
+[source,bash]
+----
+SIMPLE_WEBAPP_SAML_URL=https://$(oc get route saml-app --template='{{ .spec.host }}') &&
+echo "" &&
+echo "Application URL:              $SIMPLE_WEBAPP_SAML_URL/simple-webapp-saml" &&
+echo "Master SAML Processing URL:   $SIMPLE_WEBAPP_SAML_URL/simple-webapp-saml/saml" &&
+echo ""
+----
+
+We'll make use of these URLs in the next two sections.
+
+== Finish Configuring Keycloak
+
+From your `simple-webapp-saml` client in the *Keycloak Administration Console*,
+In the client settings, set `Master SAML Processing URL` to the `Master SAML Processing URL` that was output
+in the previous section and then click `Save`.
+
+== Access the Application
+
+From your browser, navigate to the `Application URL`.
+
+Click on `Access Secured Servlet`.
+
+You will be redirected to Keycloak to log in.
+
+Log in using the `alice` user we created earlier.
+
+Upon successful authentication, you will be redirected back to the example application.
+
+The example application simply outputs the email address associated with our logged in user.
+
+You should see the following output:
+
+[source,text]
+----
+Current Principal 'alice@example.org'
+----
+
+This indicates that we have successfully logged into our application!
+
+== Next Steps
+
+This guide has shown how to secure an application deployed to WildFly on OpenShift with SAML. For additional
+information, feel free to check out the resources linked below.
+
+[[references]]
+== References
+
+* https://docs.wildfly.org/{wildfly-version}/Getting_Started_on_OpenShift.html[Getting Started with WildFly on OpenShift]
+* https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
+* https://docs.wildfly.org/{wildfly-version}/Getting_Started_on_OpenShift.html#helm-charts[WildFly Helm Chart]
+* https://www.keycloak.org/getting-started/getting-started-openshift[Getting started with Keycloak on OpenShift]
+* https://www.keycloak.org/docs/latest/server_admin/index.html[Keycloak Server Administration Guide]
+* https://www.keycloak.org/docs/latest/securing_apps/#using-saml-to-secure-applications-and-services[Using SAML to secure applications and services]


### PR DESCRIPTION
This PR adds an initial set of 5 security guides related to OIDC and SAML.

It also introduces some common procedure files (starting with `_proc-*`) for things like configuring Keycloak, following a build and deployment on OpenShift, installing the WildFly Helm Chart, etc. so that these common instructions can be reused in different guides.